### PR TITLE
Optimize library bundle size

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <h1 align="center">
-  :sunrise: openapi-to-ts
+  🌅 openapi-to-ts
 </h1>
 
 <p align="center">
@@ -22,13 +22,13 @@
 ## Install
 
 ```shell
-npm install openapi-to-ts
+npm install openapi-to-ts --save-dev
 ```
 
 or
 
 ```shell
-yarn add openapi-to-ts
+yarn add openapi-to-ts --dev
 ```
 
 ## CLI Usage
@@ -58,7 +58,6 @@ npx openapi-to-ts -i https://raw.githubusercontent.com/OAI/OpenAPI-Specification
 - Add an option to run prettier on the generated TS file.
 - Allow fetching OpenAPI files from private GitHub repos.
 - Implement additionalProperties.
-- Reduce bundlesize.
 - Allow usage from Node.js and not just the CLI.
 - Cover the codebase with tests.
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,12 @@
   TypeScript type generator for OpenAPI 3.0 specification files.
 </p>
 
+<div align="center">
+  [![npm downloads](https://img.shields.io/npm/dm/openapi-to-ts.svg?style=for-the-badge)](https://www.npmjs.com/package/openapi-to-ts)
+  [![npm](https://img.shields.io/npm/dt/openapi-to-ts.svg?style=for-the-badge)](https://www.npmjs.com/package/openapi-to-ts)
+  [![npm](https://img.shields.io/bundlephobia/minzip/openapi-to-ts?style=for-the-badge)](https://bundlephobia.com/result?p=openapi-to-ts)
+</div>
+
 ## Example
 
 - Input: [OpenAPI 3.0 YAML file](./examples/example.yaml)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "openapi-to-ts",
   "description": "Generate TypeScript types from OpenAPI 3.0 specs.",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "author": "Alexander Ehrenthal",
   "license": "MIT",
   "homepage": "https://github.com/aehrenthal/openapi-to-ts",
@@ -49,6 +49,7 @@
     "eslint-plugin-prettier": "^3.1.4",
     "eslint": "^7.6.0",
     "prettier": "^2.0.5",
+    "rollup-plugin-peer-deps-external": "^2.2.3",
     "rollup-plugin-terser": "^6.1.0",
     "rollup-plugin-typescript2": "^0.27.1",
     "rollup": "^2.23.0",

--- a/rollup/rollup.config.js
+++ b/rollup/rollup.config.js
@@ -1,5 +1,6 @@
 import {terser} from 'rollup-plugin-terser';
 import commonjs from '@rollup/plugin-commonjs';
+import external from 'rollup-plugin-peer-deps-external';
 import resolve from '@rollup/plugin-node-resolve';
 import typescript from 'rollup-plugin-typescript2';
 
@@ -16,19 +17,18 @@ export default {
       exports: 'named',
       file: packageJson.main,
       format: 'cjs',
-      name,
-      sourcemap: true
+      name
     },
     {
       exports: 'named',
       file: packageJson.module,
       format: 'esm',
-      name,
-      sourcemap: true
+      name
     }
   ],
   external: ['fs', 'os', 'tty', 'http', 'https', 'path'],
   plugins: [
+    external(),
     typescript({
       clean: true,
       tsconfig: path.resolve(process.cwd(), './tsconfig.json')

--- a/yarn.lock
+++ b/yarn.lock
@@ -593,9 +593,9 @@ estraverse@^4.1.0, estraverse@^4.1.1:
   integrity sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==
 
 estraverse@^5.1.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-5.1.0.tgz#374309d39fd935ae500e7b92e8a6b4c720e59642"
-  integrity sha512-FyohXK+R0vE+y1nHLoBM7ZTyqRpqAlhdZHCWIWEviFLiGB8b04H6bQs8G+XTthacvT8VuwvteiP7RJSxMs8UEw==
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-5.2.0.tgz#307df42547e6cc7324d3cf03c155d5cdb8c53880"
+  integrity sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==
 
 estree-walker@^1.0.1:
   version "1.0.1"
@@ -1253,6 +1253,11 @@ rimraf@2.6.3:
   integrity sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==
   dependencies:
     glob "^7.1.3"
+
+rollup-plugin-peer-deps-external@^2.2.3:
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-peer-deps-external/-/rollup-plugin-peer-deps-external-2.2.3.tgz#059a8aec1eefb48a475e9fcedc3b9e3deb521213"
+  integrity sha512-W6IePXTExGXVDAlfZbNUUrx3GxUOZP248u5n4a4ID1XZMrbQ+uGeNiEfapvdzwx0qZi5DNH/hDLiPUP+pzFIxg==
 
 rollup-plugin-terser@^6.1.0:
   version "6.1.0"


### PR DESCRIPTION
This pull request optimizes the libraries' unpacked bundle size by tuning the rollup config. 
It also updates the readme file to suggest saving the library to the dev dependencies by default.