### PR TITLE
V1.1.0 Support fetching specification files from private GitHub repos

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -8,6 +8,7 @@ module.exports = {
   ],
   rules: {
     'prettier/prettier': 'warn',
-    '@typescript-eslint/no-explicit-any': 'off'
+    '@typescript-eslint/no-explicit-any': 'off',
+    '@typescript-eslint/no-var-requires': 'off'
   }
 };

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 ## Features
 
 - Generates TypeScript types from OpenAPI 3.0 specification files using Node.js.
-- Retrieves specification files from the file system or remote sources.
+- Retrieve specification files from local or remote sources, including private GitHub repos.
 - Supports YAML and JSON specification files.
 - Generates interfaces and types.
 - Tiny size with only a few dependencies.
@@ -55,20 +55,62 @@ npx openapi-to-ts -i https://raw.githubusercontent.com/OAI/OpenAPI-Specification
 
 ## CLI Options
 
-| Option        | Alias | Required | Default | Description                                                                |
-| ------------- | ----- | -------- | ------- | -------------------------------------------------------------------------- |
-| --input       | -i    | Yes      |         | Specifies the OpenAPI 3.0 specification file that should be converted.     |
-| --output      | -o    | Yes      |         | Specifies the output file where the TypeScript types should be written to. |
-| --prefixWithI |       | No       | false   | Appends the letter `I` as a prefix to all interface names.                 |
+| Option                | Alias | Required | Default | Description                                                                          |
+| --------------------- | ----- | -------- | ------- | ------------------------------------------------------------------------------------ |
+| --input [input]       | -i    | Yes      |         | Specifies the OpenAPI 3.0 specification file that should be converted.               |
+| --output [output]     | -o    | Yes      |         | Specifies the output file where the TypeScript types should be written to.           |
+| --githubToken [token] |       | No       |         | Attach a GitHub personal access token to the request if fetching the input remotely. |
+| --prefixWithI         |       | No       | false   | Appends the letter `I` as a prefix to all interface names.                           |
+
+### Input & Output
+
+The input option allows you to define the location of the OpenAPI 3.0 specification file that you would like to convert. The location could be on your local file system or a remote source such as a GitHub repository.
+
+The output option allows you to define the path to which you would like to write the generated types. The output path must be on your local file system.
+
+To convert a specification file from your local file system you can run:
+
+```shell
+npx openapi-to-ts -i <PATH_TO_SPEC_FILE> -o <PATH_TO_OUTPUT>
+```
+
+This command will convert the specification file located at `./examples/example.yaml` to TypeScript types and write them to `./examples/example.ts`.
+
+The convert a specification file from a remote source, such as a GitHub repository you can run:
+
+```shell
+npx openapi-to-ts -i <URL_TO_SPEC_FILE> -o <PATH_TO_OUTPUT>
+```
+
+This command will fetch the specification file from the link specified above, convert it to TypeScript types and write the final output to the specified location.
+
+### GitHub Token for Private Repositories
+
+If your OpenAPI 3.0 specification file is located in a private GitHub repository, you can use the `--githubToken <token>` option. This will attach your personal access token to the request that fetches the remotely stored specification file. For more information on how to create a personal access token, please [click here](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token 'click here').
+
+To use this option, please run:
+
+```shell
+npx openapi-to-ts -i <URL_TO_SPEC_FILE> -o <PATH_TO_OUTPUT> --githubToken <YOUR_PERSONAL_ACCESS_TOKEN>
+```
+
+### Interface Prefixes
+
+If your schema is called `Cat` by default, the interface openapi-to-ts will generate will also be called `Cat`. However, you can optionally supply the `--prefixWithI` option to append the letter `I` to the interface's name. If you do so, the schema by the name of `Cat` will be converted to an interface called `ICat`.
+
+To use this option, please run:
+
+```shell
+npx openapi-to-ts -i <PATH_TO_SPEC_FILE> -o <PATH_TO_OUTPUT> --prefixWithI
+```
 
 ## Planned Improvements
 
 - Add an option to run prettier on the generated TS file.
-- Allow fetching OpenAPI files from private GitHub repos.
 - Implement additionalProperties.
 - Allow usage from Node.js and not just the CLI.
 - Cover the codebase with tests.
 
 ## Bugs
 
-Found a bug? Please report it [here](https://github.com/aehrenthal/openapi-to-ts/issues) and I would be happy to take a look. Contributions are more than welcome too!
+Found a bug? Please report it [here](https://github.com/aehrenthal/openapi-to-ts/issues), and I would be happy to take a look. Contributions are more than welcome too!

--- a/README.md
+++ b/README.md
@@ -74,9 +74,9 @@ To convert a specification file from your local file system you can run:
 npx openapi-to-ts -i <PATH_TO_SPEC_FILE> -o <PATH_TO_OUTPUT>
 ```
 
-This command will convert the specification file located at `./examples/example.yaml` to TypeScript types and write them to `./examples/example.ts`.
+This command will convert the specification file located at `<PATH_TO_SPEC_FILE>` to TypeScript types and write them to `<PATH_TO_OUTPUT>`.
 
-The convert a specification file from a remote source, such as a GitHub repository you can run:
+To convert a specification file from a remote source, such as a GitHub repository you can run:
 
 ```shell
 npx openapi-to-ts -i <URL_TO_SPEC_FILE> -o <PATH_TO_OUTPUT>
@@ -86,7 +86,7 @@ This command will fetch the specification file from the link specified above, co
 
 ### GitHub Token for Private Repositories
 
-If your OpenAPI 3.0 specification file is located in a private GitHub repository, you can use the `--githubToken <token>` option. This will attach your personal access token to the request that fetches the remotely stored specification file. For more information on how to create a personal access token, please [click here](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token 'click here').
+If your OpenAPI 3.0 specification file is located in a private GitHub repository, you can use the `--githubToken <token>` option. This will attach your personal access token to the request that fetches the remotely stored specification file. For more information on how to create a personal access token in GitHub, please [click here](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token).
 
 To use this option, please run:
 
@@ -96,7 +96,7 @@ npx openapi-to-ts -i <URL_TO_SPEC_FILE> -o <PATH_TO_OUTPUT> --githubToken <YOUR_
 
 ### Interface Prefixes
 
-If your schema is called `Cat` by default, the interface openapi-to-ts will generate will also be called `Cat`. However, you can optionally supply the `--prefixWithI` option to append the letter `I` to the interface's name. If you do so, the schema by the name of `Cat` will be converted to an interface called `ICat`.
+If your schema is called `Cat`, by default openapi-to-ts will generate the interface with the name `Cat`. However, you can optionally supply the `--prefixWithI` option to append the letter `I` to the interface's name. If you do so, the schema by the name of `Cat` will be converted to an interface called `ICat`.
 
 To use this option, please run:
 

--- a/bin/openapi-to-ts.js
+++ b/bin/openapi-to-ts.js
@@ -10,6 +10,10 @@ program
   .description(packageJson.description)
   .requiredOption('-i, --input <input>', 'Convert specified OpenAPI 3.0 specification file to TypeScript types.')
   .requiredOption('-o, --output <output>', 'Specify the output file the TypeScript types should be written to.')
+  .option(
+    '--githubToken <token>',
+    'Attach a GitHub personal access token to the request if fetching the input remotely.'
+  )
   .option('--prefixWithI', 'Append the letter `I` as a prefix to all interface names.')
   .action(async (options) => {
     try {

--- a/bin/openapi-to-ts.js
+++ b/bin/openapi-to-ts.js
@@ -18,7 +18,7 @@ program
   .action(async (options) => {
     try {
       /** Fetch the file and convert it to JSON. */
-      const specFile = await openAPIToTS.getOpenAPISpecAsJSON(options.input);
+      const specFile = await openAPIToTS.getOpenAPISpecAsJSON(options.input, options.githubToken);
       /** Convert the OpenAPI 3.0 Spec to TypeScript types. */
       const types = openAPIToTS.convertOpenAPIToTS(specFile, options);
       /** Write the file to the file system. */

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "openapi-to-ts",
   "description": "Generate TypeScript types from OpenAPI 3.0 specs.",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "author": "Alexander Ehrenthal",
   "license": "MIT",
   "homepage": "https://github.com/aehrenthal/openapi-to-ts",

--- a/src/getOpenAPISpecAsJSON.ts
+++ b/src/getOpenAPISpecAsJSON.ts
@@ -12,8 +12,9 @@ const isRemoteFile = /^(?:http(s)?:\/\/)?[\w.-]+(?:\.[\w\.-]+)+[\w\-\._~:/?#[\]@
  * and converts it into JSON. It can either be on a remote
  * server or on the local file system of the user.
  * @param filePath the path to the OpenAPI 3.0 specification file to convert.
+ * @param githubToken the github token that should be attached to the request.
  */
-export const getOpenAPISpecAsJSON = async (filePath: string): Promise<IOpenAPISpecFile> => {
+export const getOpenAPISpecAsJSON = async (filePath: string, githubToken?: string): Promise<IOpenAPISpecFile> => {
   console.log(chalk.blue(`Loading OpenAPI 3.0 specification file from: ${filePath}`));
 
   try {
@@ -21,7 +22,7 @@ export const getOpenAPISpecAsJSON = async (filePath: string): Promise<IOpenAPISp
     let rawSpecFile: string | undefined = undefined;
 
     if (isRemoteFile.test(filePath)) {
-      rawSpecFile = await getRemoteFile(filePath);
+      rawSpecFile = await getRemoteFile(filePath, githubToken);
     } else {
       rawSpecFile = await getLocalFile(filePath);
     }

--- a/src/utils/getRemoteFile.ts
+++ b/src/utils/getRemoteFile.ts
@@ -14,19 +14,22 @@ export const getRemoteFile = (filePath: string, githubToken?: string): Promise<s
      * on the protocol. The default client is HTTP.
      */
     let client: any = http;
-
     if (filePath.toString().indexOf('https') === 0) {
       client = https;
     }
 
-    /* const options = {
-      headers: {
-        Authorization: `token ${githubToken}`
-      }
-    }; */
+    /** Add authorization headers if a github token is specified. */
+    let options = {};
+    if (githubToken) {
+      options = {
+        headers: {
+          Authorization: `token ${githubToken}`
+        }
+      };
+    }
 
     client
-      .get(`${filePath}?token=${githubToken}`, (response: any) => {
+      .get(filePath, options, (response: any) => {
         /** Encode the response in UTF-8. */
         response.setEncoding('utf-8');
 
@@ -39,7 +42,13 @@ export const getRemoteFile = (filePath: string, githubToken?: string): Promise<s
 
         /** Executed when the whole response has been received. */
         response.on('end', () => {
-          resolve(data);
+          if (response.statusCode !== 200) {
+            let errorMessage = `There was an HTTP error fetching your specification file: ${response.statusCode} ${response.statusMessage}.\n`;
+            if (githubToken) errorMessage += 'Either the file does not exist, or your personal access token is wrong.';
+            reject(errorMessage);
+          } else {
+            resolve(data);
+          }
         });
       })
       .on('error', () => {

--- a/src/utils/getRemoteFile.ts
+++ b/src/utils/getRemoteFile.ts
@@ -5,8 +5,9 @@ import https from 'https';
  * This function loads the content of a file located
  * on a remote server.
  * @param filePath the path of the file.
+ * @param githubToken the github token that should be attached to the request.
  */
-export const getRemoteFile = (filePath: string): Promise<string> => {
+export const getRemoteFile = (filePath: string, githubToken?: string): Promise<string> => {
   return new Promise(async (resolve, reject) => {
     /**
      * We need to choose a different HTTP client depending
@@ -18,8 +19,14 @@ export const getRemoteFile = (filePath: string): Promise<string> => {
       client = https;
     }
 
+    /* const options = {
+      headers: {
+        Authorization: `token ${githubToken}`
+      }
+    }; */
+
     client
-      .get(filePath, (response: any) => {
+      .get(`${filePath}?token=${githubToken}`, (response: any) => {
         /** Encode the response in UTF-8. */
         response.setEncoding('utf-8');
 


### PR DESCRIPTION
This pull request adds support to fetch specification files from private GitHub repositories.
- Add support for fetching specification files from private GitHub repositories.
- Improved error handling for remote specification file fetching.
- Updated readme to describe the CLI options in more detail.